### PR TITLE
兼容旧版本FMDB 比如    pod 'FMDB', '2.5'

### DIFF
--- a/DebugDatabase/DatabaseUtil.m
+++ b/DebugDatabase/DatabaseUtil.m
@@ -155,7 +155,7 @@
             }else if ([[type lowercaseString] isEqualToString:@"guid"]){
                 
                 
-                id data = [rs respondsToSelector:@selector(objectForColumn:)] ? [rs objectForColumn:columName] : [rs objectForColumnName:columName];
+                id data = [rs respondsToSelector:@selector(objectForColumn:)] ? [rs performSelector:@selector(objectForColumn:) withObject:columName] : [rs performSelector:@selector(objectForColumnName:) withObject:columName];
                 const unsigned char *bytes = (const unsigned char *)[data bytes];
                 NSMutableString *hex = [NSMutableString new];
                 for (NSInteger i = 0; i < [data length]; i++) {
@@ -164,7 +164,7 @@
                 
                 [columnData safe_setObject:hex?:[NSNull null] forKey:@"value"];
             }else {
-                id obj = [rs respondsToSelector:@selector(objectForColumn:)] ? [rs objectForColumn:columName] : [rs objectForColumnName:columName];
+                id obj = [rs respondsToSelector:@selector(objectForColumn:)] ? [rs performSelector:@selector(objectForColumn:) withObject:columName] : [rs performSelector:@selector(objectForColumnName:) withObject:columName];
                 [columnData safe_setObject:obj?:[NSNull null] forKey:@"value"];
             }
             


### PR DESCRIPTION
改为动态调用 [rs performSelector:@selector(objectForColumn:) withObject:columName]，不然在低版本的FMDB依然会编译报错。我是Dokit https://github.com/didi/DoraemonKit/ 的成员，我们引用到你这个仓库，很多人反馈了这个问题。麻烦更新一下。